### PR TITLE
AdvPartScript testing and adjustments

### DIFF
--- a/HaruhiGekidouLib/Script/AdvPartScript.cs
+++ b/HaruhiGekidouLib/Script/AdvPartScript.cs
@@ -166,7 +166,7 @@ public class AdvPartScriptBlock
     {
         for (int i = 0; i < data.Length;)
         {
-            string invocationString = IO.ReadShiftJisString(data, i);
+            string invocationString = IO.ReadShiftJisString(data, i); //issue potentially here - some commands aren't being read correctly
             Commands.Add(new(invocationString));
             i += invocationString.GetShiftJisLength() + 1;
         }
@@ -176,7 +176,7 @@ public class AdvPartScriptBlock
     {
         List<byte> bytes = [.. Commands.SelectMany(c => c.GetBytes())];
         
-        bytes.InsertRange(0, IO.GetIntBytes(bytes.Count));
+        bytes.InsertRange(0, IO.GetIntBytes(bytes.Count)); //issue located in AdvPart_Scene_001 - count is 10 under
         
         return [.. bytes];
     }

--- a/HaruhiGekidouLib/Script/AdvPartScript.cs
+++ b/HaruhiGekidouLib/Script/AdvPartScript.cs
@@ -56,12 +56,14 @@ public partial class AdvPartScript
 
         List<byte[]> scriptBlockBytes = [.. ScriptBlocks.Select(b => b.GetBytes())];
         
-        bytes.AddRange(IO.GetIntBytes(1));
+        bytes.AddRange(IO.GetIntBytes(ScriptBlocks.Count));
         int startLocation = 0x104;
         foreach (byte[] data in scriptBlockBytes)
         {
             bytes.AddRange(IO.GetIntBytes(startLocation));
-            startLocation += data.Length + 4;
+            startLocation += data.Length + (0x20 - (startLocation+data.Length) % 0x20);
+                             
+                             //((data.Length+0x104) % 0x20);
         }
         for (int i = 0; i < 64 - ScriptBlocks.Count; i++)
         {
@@ -71,7 +73,13 @@ public partial class AdvPartScript
         foreach (byte[] data in scriptBlockBytes)
         {
             bytes.AddRange(data);
+            if (bytes.Count % 0x20 != 0)
+            {
+                bytes.AddRange(new byte[0x20 - bytes.Count() % 0x20]);
+            }
         }
+        
+
         
         return [.. bytes];
     }

--- a/HaruhiGekidouTests/SourceTests.cs
+++ b/HaruhiGekidouTests/SourceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -44,6 +45,11 @@ namespace HaruhiGekidouTests.Tests
             "Tutorial_006"
         ];
 
+        public static string[] _AdvPartScriptFiles()
+        {
+            return Directory.GetFiles("./input/AdvPartScript/");
+        }
+
 
         [Test]
         [TestCaseSource(nameof(_scriptArcNames))]
@@ -69,17 +75,22 @@ namespace HaruhiGekidouTests.Tests
         
         
 
-//        testing AdvScript files - unfinished right now
-//        [Test]
-//        [Parallelizable(ParallelScope.All)]
-//        public void validateScript(byte[] script)
-//        {
-//            //create new script based on input
-//            AdvPartScript Newscript = new("TestScript", script);
-//            byte[] newScriptBytes = Newscript.GetBytes();
-//
-//            //compare
-//           ClassicAssert.AreEqual(script, newScriptBytes);
-//        }
+        [Test]
+        [TestCaseSource(nameof(_AdvPartScriptFiles))]
+        [Parallelizable(ParallelScope.All)]
+        public void validateScript(string scriptPath)
+        {
+            
+            byte[] scriptBytes = File.ReadAllBytes(scriptPath);
+
+            AdvPartScript newScript = new("TestScript", scriptBytes);
+            byte[] newScriptBytes = newScript.GetBytes();
+            
+            //save them out
+            Directory.CreateDirectory("./output/AdvPartScript/");
+            File.WriteAllBytes("./output/AdvPartScript/" + Path.GetFileName(scriptPath), newScriptBytes);
+            //compare
+            Assert.That(newScriptBytes, Is.EqualTo(scriptBytes));
+        }
     }
 }

--- a/HaruhiGekidouTests/SourceTests.cs
+++ b/HaruhiGekidouTests/SourceTests.cs
@@ -82,8 +82,8 @@ namespace HaruhiGekidouTests.Tests
                                     name += arc.Split("_")[1];
                                     
                                 }
-                                File.WriteAllBytes(Path.Combine(Path.Combine("input", "AdvPartScript"), name + ".bin"), entry.Data);
-                                newScripts.Add(Path.Combine(Path.Combine("input", "AdvPartScript"), name + ".bin"));
+                                File.WriteAllBytes(Path.Combine("input", "AdvPartScript", name + ".bin"), entry.Data);
+                                newScripts.Add(Path.Combine("input", "AdvPartScript", name + ".bin"));
                             }
                         }
 

--- a/HaruhiGekidouTests/SourceTests.cs
+++ b/HaruhiGekidouTests/SourceTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -47,7 +49,43 @@ namespace HaruhiGekidouTests.Tests
 
         public static string[] _AdvPartScriptFiles()
         {
-            return Directory.GetFiles("./input/AdvPartScript/");
+            if (Directory.Exists("./input/AdvPartScript/"))
+            {
+                return Directory.GetFiles("./input/AdvPartScript/");
+            }
+            else
+            {
+                Directory.CreateDirectory("./input/AdvPartScript/");
+
+                List<string> newScripts = new List<string>();
+                string [] arcs = Directory.GetFiles("./input/ScriptArc/");
+                foreach (string arc in arcs)
+                {
+                    if (_scriptArcNames.Contains(Path.GetFileNameWithoutExtension(arc)))
+                    {
+                        byte[] arcBytes = File.ReadAllBytes(arc);
+                        GekidouArc newArc = new(arcBytes);
+                        
+                        bool isInScript = false;
+                        foreach (GekidouArcEntry entry in newArc.Entries)
+                        {
+                            if (entry.IsDirectory)
+                            {
+                                isInScript = entry.Name == "AdvPartScript";
+                            }
+                            else
+                            {
+                                if (!isInScript) continue;
+                               
+                                File.WriteAllBytes(Path.Combine("./input/AdvPartScript/", entry.Name), entry.Data);
+                                newScripts.Add(Path.Combine("./input/AdvPartScript/", entry.Name));
+                            }
+                        }
+
+                    }
+                }
+                return newScripts.ToArray();
+            }
         }
 
 

--- a/HaruhiGekidouTests/SourceTests.cs
+++ b/HaruhiGekidouTests/SourceTests.cs
@@ -47,18 +47,18 @@ namespace HaruhiGekidouTests.Tests
             "Tutorial_006"
         ];
 
-        public static string[] _AdvPartScriptFiles()
+        public static string[] AdvPartScriptFiles()
         {
-            if (Directory.Exists("./input/AdvPartScript/"))
+            if (Directory.Exists(Path.Combine("input", "AdvPartScript")))
             {
-                return Directory.GetFiles("./input/AdvPartScript/");
+                return Directory.GetFiles(Path.Combine("input", "AdvPartScript"));
             }
             else
             {
-                Directory.CreateDirectory("./input/AdvPartScript/");
+                Directory.CreateDirectory(Path.Combine("input", "AdvPartScript"));
 
                 List<string> newScripts = new List<string>();
-                string [] arcs = Directory.GetFiles("./input/ScriptArc/");
+                string [] arcs = Directory.GetFiles(Path.Combine("input", "ScriptArc"));
                 foreach (string arc in arcs)
                 {
                     if (_scriptArcNames.Contains(Path.GetFileNameWithoutExtension(arc)))
@@ -82,8 +82,8 @@ namespace HaruhiGekidouTests.Tests
                                     name += arc.Split("_")[1];
                                     
                                 }
-                                File.WriteAllBytes(Path.Combine("./input/AdvPartScript/", name + ".bin"), entry.Data);
-                                newScripts.Add(Path.Combine("./input/AdvPartScript/", name + ".bin"));
+                                File.WriteAllBytes(Path.Combine(Path.Combine("input", "AdvPartScript"), name + ".bin"), entry.Data);
+                                newScripts.Add(Path.Combine(Path.Combine("input", "AdvPartScript"), name + ".bin"));
                             }
                         }
 
@@ -119,7 +119,7 @@ namespace HaruhiGekidouTests.Tests
         
 
         [Test]
-        [TestCaseSource(nameof(_AdvPartScriptFiles))]
+        [TestCaseSource(nameof(AdvPartScriptFiles))]
         [Parallelizable(ParallelScope.All)]
         public void validateScript(string scriptPath)
         {

--- a/HaruhiGekidouTests/SourceTests.cs
+++ b/HaruhiGekidouTests/SourceTests.cs
@@ -76,9 +76,14 @@ namespace HaruhiGekidouTests.Tests
                             else
                             {
                                 if (!isInScript) continue;
-                               
-                                File.WriteAllBytes(Path.Combine("./input/AdvPartScript/", entry.Name), entry.Data);
-                                newScripts.Add(Path.Combine("./input/AdvPartScript/", entry.Name));
+                                string name = Path.GetFileNameWithoutExtension(entry.Name);
+                                if (arc.Contains("Tutorial"))
+                                {
+                                    name += arc.Split("_")[1];
+                                    
+                                }
+                                File.WriteAllBytes(Path.Combine("./input/AdvPartScript/", name + ".bin"), entry.Data);
+                                newScripts.Add(Path.Combine("./input/AdvPartScript/", name + ".bin"));
                             }
                         }
 


### PR DESCRIPTION
Implemented correspondence testing in AdvPartScript files as well as adjustments to improve byte-for-byte correspondence.

The setup for preparing the files for testing is a little janky, but it seems to do the trick!